### PR TITLE
Update python_version for 3.13

### DIFF
--- a/moloch.json
+++ b/moloch.json
@@ -14,7 +14,7 @@
     "utctime_updated": "2025-04-28T20:52:14.468036Z",
     "package_name": "phantom_moloch",
     "main_module": "moloch_connector.py",
-    "python_version": "3",
+    "python_version": ["3.9", "3.13"],
     "fips_compliant": true,
     "min_phantom_version": "5.1.0",
     "latest_tested_versions": [

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,2 @@
 **Unreleased**
+* Update Python version for 3.13


### PR DESCRIPTION
- Update python_version in app JSON files to support Python 3.9 and 3.13

[_Created by Sourcegraph batch change `grokas-splunk/002-update-python-versions`._](https://sourcegraph.splunkdev.net/users/grokas-splunk/batch-changes/002-update-python-versions)